### PR TITLE
Use soapbox rebased + production build for soapbox FE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------------------------
 
-FROM node:16-alpine3.14 as fe-build
+FROM node:18-alpine3.15 as fe-build
 
 ARG NODE_ENV=production
 
@@ -12,7 +12,9 @@ WORKDIR /build
 
 RUN set -ex \
 &&  yarn \
+&&  yarn install \
 &&  yarn add danger \
+&&  yarn add typescript --dev \
 &&  yarn build \
 &&  mkdir -p /release \
 &&  zip -r /release/soapbox-fe.zip ./static
@@ -40,7 +42,7 @@ RUN set -ex \
 
 # -------------------------------------------------------------------------------------------------------
 
-FROM alpine:3.14
+FROM alpine:3.16
 
 LABEL maintainer="ken@epenguin.com"
 


### PR DESCRIPTION
Soapbox has changed SOAPBOX-BE to rebase, and their official docker image is based on Ubuntu 20.04.

We will remain to use alpine 3.16 as the base.  In addition, we will use the gitlab CI/CD production build for FE.